### PR TITLE
Fix goran retry logic

### DIFF
--- a/lib/goran.rb
+++ b/lib/goran.rb
@@ -28,7 +28,7 @@ module Goran
         if retry_if.kind_of?(Proc)
           needs_retry_based_on_result = retry_if.call(result) # true if retry is needed
         else
-          needs_retry_based_on_result = (retry_if != result) # true if retry is needed
+          needs_retry_based_on_result = (retry_if == result) # true if retry is needed
         end
 
         if !needs_retry_based_on_result

--- a/lib/goran/version.rb
+++ b/lib/goran/version.rb
@@ -1,3 +1,3 @@
 module Goran
-  VERSION = '0.7'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
Previously, the code block was this:

```ruby
if retry_if.kind_of?(Proc)
  break unless retry_if.call(result)
elsif retry_if != result
 break
end
```

With the #1 the retry logic was updated to this:
```ruby
if retry_if.kind_of?(Proc)
 needs_retry_based_on_result = retry_if.call(result) # true if retry is needed
else
 needs_retry_based_on_result = (retry_if != result) # true if retry is needed
end
```

It should only need to retry if the result is equal to the retry_if condition

Fixed tests also to reflect this change in logic

Updated tests tested on old code prior to #1. 
<img width="1120" alt="Screenshot 2025-05-19 at 2 59 21 PM" src="https://github.com/user-attachments/assets/ffd9c6a6-4753-4a16-9f89-1d5dbd3a7bb0" />
As expected, sleep tests will fail, other tests are passing.

Updated tests tested on #1 code:
<img width="1025" alt="Screenshot 2025-05-19 at 3 01 11 PM" src="https://github.com/user-attachments/assets/0508980a-ff94-435e-9cd6-c1d6f2a1b121" />
Tests pertaining to retry logic fail

All tests pass on current PR code.